### PR TITLE
Update Menu Timeout

### DIFF
--- a/overrides/user_overrides.yml
+++ b/overrides/user_overrides.yml
@@ -12,6 +12,9 @@ site_name: ACM@UIC
 # set desired boot domain
 boot_domain: boot.acmuic.org
 
+# set default boot option timeout in milliseconds
+boot_timeout: 5000
+
 # set boot version
 # boot_version: "2.x"
 


### PR DESCRIPTION
Update menu timeout to 5 seconds instead of 5 minutes.

This will allow machines to boot the default option quicker when imaging is not needed.